### PR TITLE
Fix JavaScript syntax error that blocked game start

### DIFF
--- a/xenoblade-heardle.html
+++ b/xenoblade-heardle.html
@@ -143,8 +143,7 @@
 
   /* ==================== UTILS ==================== */
   const $ = sel => document.querySelector(sel);
-  function log(msg){ const d=$('#diag'); d.textContent=(d.textContent+"
-"+msg).trim().slice(-2000); d.scrollTop=d.scrollHeight; }
+  function log(msg){ const d=$('#diag'); d.textContent=(d.textContent+' '+msg).trim().slice(-2000); d.scrollTop=d.scrollHeight; }
   const sleep = ms => new Promise(r=>setTimeout(r,ms));
 
   function dailyIndex(mod){ const day=Math.floor(Date.now()/86400000); return ((day%mod)+mod)%mod; }


### PR DESCRIPTION
## Summary
- replace the broken string literal in the log helper with a single-line version to avoid a parse error

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68cd7a41f3a48328b43a9f5cff7d1a7e