### PR TITLE
Improve autoplay and configurability for Xenoblade Heardle

### DIFF
--- a/xenoblade-heardle.html
+++ b/xenoblade-heardle.html
@@ -31,6 +31,64 @@
     .small{ font-size:12px; opacity:.9 }
     @media (max-width:680px){ #container{ padding:14px } button{ padding:10px 14px; font-size:14px } progress{ width:170px } #player{ height:200px } }
   </style>
+  <script type="application/json" id="heardle-config">
+  {
+    "backgrounds": [
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0e/Schafberg_and_Wolfgangsee_2010-06-06_%2801%29.jpg/1920px-Schafberg_and_Wolfgangsee_2010-06-06_%2801%29.jpg",
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2e/Schafbergseen_2.jpg/1920px-Schafbergseen_2.jpg",
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/1/10/Dolomites_from_Seceda.jpg/1920px-Dolomites_from_Seceda.jpg",
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/Glen_Coe_from_the_Devil%27s_Staircase_-_geograph.org.uk_-_2648317.jpg/1920px-Glen_Coe_from_the_Devil%27s_Staircase_-_geograph.org.uk_-_2648317.jpg"
+    ],
+    "songs": [
+      { "title": "Main Theme", "game": "Xenoblade Chronicles", "videoId": "erKkWGfEW9U" },
+      { "title": "You Will Know Our Names", "game": "Xenoblade Chronicles", "videoId": "5aPA7gBY1ek" },
+      { "title": "Engage the Enemy", "game": "Xenoblade Chronicles", "videoId": "GTCB79fDUOY" },
+      { "title": "Gaur Plain", "game": "Xenoblade Chronicles", "videoId": "UDJtsfR51To" },
+      { "title": "Mechanical Rhythm", "game": "Xenoblade Chronicles", "videoId": "Q0W0VyaoZzY" },
+      { "title": "Time to Fight!", "game": "Xenoblade Chronicles", "videoId": "8S0KGphqJVk" },
+      { "title": "A Tragic Decision", "game": "Xenoblade Chronicles", "videoId": "wLXyb_wJPc4" },
+      { "title": "Beyond the Sky", "game": "Xenoblade Chronicles", "videoId": "OPWseKK3XvI" },
+      { "title": "The End Lies Ahead", "game": "Xenoblade Chronicles", "videoId": "SLW7hAaGCGo" },
+      { "title": "Colony 9", "game": "Xenoblade Chronicles", "videoId": "5oV76gY6v1Y" },
+      { "title": "Satorl Marsh", "game": "Xenoblade Chronicles", "videoId": "0cYqChCNT6c" },
+      { "title": "Visions of the Future", "game": "Xenoblade Chronicles", "videoId": "x2WUz8Bwcro" },
+      { "title": "Zanza the Divine", "game": "Xenoblade Chronicles", "videoId": "MnVemwebkiY" },
+      { "title": "Counterattack", "game": "Xenoblade Chronicles 2", "videoId": "aElM_uHL00E" },
+      { "title": "Drifting Soul", "game": "Xenoblade Chronicles 2", "videoId": "cvTb1VgABw8" },
+      { "title": "One Last You", "game": "Xenoblade Chronicles 2", "videoId": "R6WKA_7LZHI" },
+      { "title": "Mor Ardain - Roaming the Wastes", "game": "Xenoblade Chronicles 2", "videoId": "Tx3AbguQZHU" },
+      { "title": "Incoming!", "game": "Xenoblade Chronicles 2", "videoId": "zukZtQQ2hDU" },
+      { "title": "Elysium, in the Blue Sky", "game": "Xenoblade Chronicles 2", "videoId": "zF5G9seFrY8" },
+      { "title": "Gormott", "game": "Xenoblade Chronicles 2", "videoId": "zG8MREuNu5U" },
+      { "title": "You Will Recall Our Names", "game": "Xenoblade Chronicles 2", "videoId": "b0KzIa_0hAM" },
+      { "title": "After Despair and Hope", "game": "Xenoblade Chronicles 2", "videoId": "XOKm2LsOkA4" },
+      { "title": "The Decision", "game": "Xenoblade Chronicles 2", "videoId": "q3Bxm7k0l6Q" },
+      { "title": "The Beginning of Our Memory", "game": "XC2: Torna ~ The Golden Country", "videoId": "w2UNfYAvJyc" },
+      { "title": "Battle!! / Torna", "game": "XC2: Torna ~ The Golden Country", "videoId": "pWJeC-j0g3U" },
+      { "title": "Auresco, Royal Capital", "game": "XC2: Torna ~ The Golden Country", "videoId": "q3UqI0tL4y8" },
+      { "title": "A Moment of Eternity", "game": "XC2: Torna ~ The Golden Country", "videoId": "vV_p0CRn2yI" },
+      { "title": "Over Despair and Animus", "game": "XC2: Torna ~ The Golden Country", "videoId": "u5pYNFkK0hQ" },
+      { "title": "The Weight of Life", "game": "Xenoblade Chronicles 3", "videoId": "aQpeLBl6uUk" },
+      { "title": "A Life Sent On", "game": "Xenoblade Chronicles 3", "videoId": "YNYXLWYcu-A" },
+      { "title": "Chain Attack!", "game": "Xenoblade Chronicles 3", "videoId": "TYPSEjoOV9A" },
+      { "title": "Battle!!", "game": "Xenoblade Chronicles 3", "videoId": "RVxRnELD0Uw" },
+      { "title": "Keves Battle", "game": "Xenoblade Chronicles 3", "videoId": "_sQnu-YKjL4" },
+      { "title": "Moebius Battle", "game": "Xenoblade Chronicles 3", "videoId": "q8Y-37ybYiM" },
+      { "title": "Where We Belong", "game": "Xenoblade Chronicles 3", "videoId": "gyhx91rLaJI" },
+      { "title": "A Step Away", "game": "Xenoblade Chronicles 3", "videoId": "-TlbGC7nPmA" },
+      { "title": "Yzana Plains", "game": "Xenoblade Chronicles 3", "videoId": "IUhvL0y6a2k" },
+      { "title": "Off-Seer - Noah", "game": "Xenoblade Chronicles 3", "videoId": "V7B_Ed1e4gU" },
+      { "title": "New Battle!!!", "game": "XC3: Future Redeemed", "videoId": "D3hF0g2k5qE" },
+      { "title": "Shining Aspiration - Inherited Melody", "game": "XC3: Future Redeemed", "videoId": "g9S0z6Xv2hQ" },
+      { "title": "Black Mountain - The Untrodden Path", "game": "XC3: Future Redeemed", "videoId": "2z8B6T5W2pU" },
+      { "title": "Legacy", "game": "XC3: Future Redeemed", "videoId": "Xz3xKnVrEms" },
+      { "title": "Beyond Fate", "game": "XC3: Future Redeemed", "videoId": "4YkCjkq2z1Q" },
+      { "title": "Black Tar", "game": "Xenoblade Chronicles X", "videoId": "" },
+      { "title": "No.EX01", "game": "Xenoblade Chronicles X", "videoId": "" },
+      { "title": "Codename Z", "game": "Xenoblade Chronicles X", "videoId": "" }
+    ]
+  }
+  </script>
 </head>
 <body>
   <div id="container">
@@ -69,71 +127,120 @@
   </div>
 
 <script>
-  /* ==================== CONFIG ==================== */
-  const BACKGROUNDS = [
-    // Use Commons + proxy-friendly URLs to avoid hotlink/CORS issues.
-    'https://upload.wikimedia.org/wikipedia/commons/thumb/0/0e/Schafberg_and_Wolfgangsee_2010-06-06_%2801%29.jpg/1920px-Schafberg_and_Wolfgangsee_2010-06-06_%2801%29.jpg',
-    'https://upload.wikimedia.org/wikipedia/commons/thumb/2/2e/Schafbergseen_2.jpg/1920px-Schafbergseen_2.jpg',
-    'https://upload.wikimedia.org/wikipedia/commons/thumb/1/10/Dolomites_from_Seceda.jpg/1920px-Dolomites_from_Seceda.jpg',
-    'https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/Glen_Coe_from_the_Devil%27s_Staircase_-_geograph.org.uk_-_2648317.jpg/1920px-Glen_Coe_from_the_Devil%27s_Staircase_-_geograph.org.uk_-_2648317.jpg'
-  ];
+  /* ==================== HELPERS ==================== */
+  const $ = sel => document.querySelector(sel);
+  function log(msg){ const d=$('#diag'); if(!d) return; d.textContent=(d.textContent+' '+msg).trim().slice(-2000); d.scrollTop=d.scrollHeight; }
+  const sleep = ms => new Promise(r=>setTimeout(r,ms));
 
-  const SONGS = [
-    // XC1
-    { title:'Main Theme', game:'Xenoblade Chronicles', videoId:'erKkWGfEW9U' },
-    { title:'You Will Know Our Names', game:'Xenoblade Chronicles', videoId:'5aPA7gBY1ek' },
-    { title:'Engage the Enemy', game:'Xenoblade Chronicles', videoId:'GTCB79fDUOY' },
-    { title:'Gaur Plain', game:'Xenoblade Chronicles', videoId:'UDJtsfR51To' },
-    { title:'Mechanical Rhythm', game:'Xenoblade Chronicles', videoId:'Q0W0VyaoZzY' },
-    { title:'Time to Fight!', game:'Xenoblade Chronicles', videoId:'8S0KGphqJVk' },
-    { title:'A Tragic Decision', game:'Xenoblade Chronicles', videoId:'wLXyb_wJPc4' },
-    { title:'Beyond the Sky', game:'Xenoblade Chronicles', videoId:'OPWseKK3XvI' },
-    { title:'The End Lies Ahead', game:'Xenoblade Chronicles', videoId:'SLW7hAaGCGo' },
-    { title:'Colony 9', game:'Xenoblade Chronicles', videoId:'5oV76gY6v1Y' },
-    { title:'Satorl Marsh', game:'Xenoblade Chronicles', videoId:'0cYqChCNT6c' },
-    { title:'Visions of the Future', game:'Xenoblade Chronicles', videoId:'x2WUz8Bwcro' },
-    { title:'Zanza the Divine', game:'Xenoblade Chronicles', videoId:'MnVemwebkiY' },
-    // XC2
-    { title:'Counterattack', game:'Xenoblade Chronicles 2', videoId:'aElM_uHL00E' },
-    { title:'Drifting Soul', game:'Xenoblade Chronicles 2', videoId:'cvTb1VgABw8' },
-    { title:'One Last You', game:'Xenoblade Chronicles 2', videoId:'R6WKA_7LZHI' },
-    { title:'Mor Ardain - Roaming the Wastes', game:'Xenoblade Chronicles 2', videoId:'Tx3AbguQZHU' },
-    { title:'Incoming!', game:'Xenoblade Chronicles 2', videoId:'zukZtQQ2hDU' },
-    { title:'Elysium, in the Blue Sky', game:'Xenoblade Chronicles 2', videoId:'zF5G9seFrY8' },
-    { title:'Gormott', game:'Xenoblade Chronicles 2', videoId:'zG8MREuNu5U' },
-    { title:'You Will Recall Our Names', game:'Xenoblade Chronicles 2', videoId:'b0KzIa_0hAM' },
-    { title:'After Despair and Hope', game:'Xenoblade Chronicles 2', videoId:'XOKm2LsOkA4' },
-    { title:'The Decision', game:'Xenoblade Chronicles 2', videoId:'q3Bxm7k0l6Q' },
-    // Torna
-    { title:'The Beginning of Our Memory', game:'XC2: Torna ~ The Golden Country', videoId:'w2UNfYAvJyc' },
-    { title:'Battle!! / Torna', game:'XC2: Torna ~ The Golden Country', videoId:'pWJeC-j0g3U' },
-    { title:'Auresco, Royal Capital', game:'XC2: Torna ~ The Golden Country', videoId:'q3UqI0tL4y8' },
-    { title:'A Moment of Eternity', game:'XC2: Torna ~ The Golden Country', videoId:'vV_p0CRn2yI' },
-    { title:'Over Despair and Animus', game:'XC2: Torna ~ The Golden Country', videoId:'u5pYNFkK0hQ' },
-    // XC3
-    { title:'The Weight of Life', game:'Xenoblade Chronicles 3', videoId:'aQpeLBl6uUk' },
-    { title:'A Life Sent On', game:'Xenoblade Chronicles 3', videoId:'YNYXLWYcu-A' },
-    { title:'Chain Attack!', game:'Xenoblade Chronicles 3', videoId:'TYPSEjoOV9A' },
-    { title:'Battle!!', game:'Xenoblade Chronicles 3', videoId:'RVxRnELD0Uw' },
-    { title:'Keves Battle', game:'Xenoblade Chronicles 3', videoId:'_sQnu-YKjL4' },
-    { title:'Moebius Battle', game:'Xenoblade Chronicles 3', videoId:'q8Y-37ybYiM' },
-    { title:'Where We Belong', game:'Xenoblade Chronicles 3', videoId:'gyhx91rLaJI' },
-    { title:'A Step Away', game:'Xenoblade Chronicles 3', videoId:'-TlbGC7nPmA' },
-    { title:'Yzana Plains', game:'Xenoblade Chronicles 3', videoId:'IUhvL0y6a2k' },
-    { title:'Off-Seer - Noah', game:'Xenoblade Chronicles 3', videoId:'V7B_Ed1e4gU' },
-    // Future Redeemed
-    { title:'New Battle!!!', game:'XC3: Future Redeemed', videoId:'D3hF0g2k5qE' },
-    { title:'Shining Aspiration - Inherited Melody', game:'XC3: Future Redeemed', videoId:'g9S0z6Xv2hQ' },
-    { title:'Black Mountain - The Untrodden Path', game:'XC3: Future Redeemed', videoId:'2z8B6T5W2pU' },
-    { title:'Legacy', game:'XC3: Future Redeemed', videoId:'Xz3xKnVrEms' },
-    { title:'Beyond Fate', game:'XC3: Future Redeemed', videoId:'4YkCjkq2z1Q' },
-    // XCX placeholders (safe to keep empty—they're skipped automatically)
-    { title:'Black Tar', game:'Xenoblade Chronicles X', videoId:'' },
-    { title:'No.EX01', game:'Xenoblade Chronicles X', videoId:'' },
-    { title:'Codename Z', game:'Xenoblade Chronicles X', videoId:'' }
-  ];
+  /* ==================== CONFIG ==================== */
+  const STORAGE_KEY = 'xeno-heardle-custom-config-v1';
+  const safeJSONParse = (value, fallback) => {
+    if (!value) return fallback;
+    try { return JSON.parse(value); } catch { return fallback; }
+  };
+
+  const normalizeBackgrounds = (arr=[]) => arr
+    .filter(item => typeof item === 'string')
+    .map(item => item.trim())
+    .filter(Boolean);
+
+  const normalizeSongs = (arr=[]) => {
+    const result=[];
+    for (const raw of Array.isArray(arr)?arr:[]){
+      if(!raw) continue;
+      const title = (raw.title ?? '').toString().trim();
+      const game = (raw.game ?? '').toString().trim();
+      const videoId = (raw.videoId ?? '').toString().trim();
+      if(!title) continue;
+      result.push({ title, game: game || 'Unknown', videoId });
+    }
+    return result;
+  };
+
+  const dedupeBackgrounds = (arr=[]) => {
+    const seen=new Set();
+    const out=[];
+    for (const url of Array.isArray(arr)?arr:[]){
+      if(!url) continue;
+      const key=url.toLowerCase();
+      if(seen.has(key)) continue;
+      seen.add(key);
+      out.push(url);
+    }
+    return out;
+  };
+
+  const dedupeSongs = (arr=[]) => {
+    const seen=new Set();
+    const out=[];
+    for (const song of Array.isArray(arr)?arr:[]){
+      if(!song || !song.title) continue;
+      const key=song.title.toLowerCase();
+      if(seen.has(key)) continue;
+      seen.add(key);
+      out.push(song);
+    }
+    return out;
+  };
+
+  const baseConfig = (()=>{
+    const node=document.getElementById('heardle-config');
+    const parsed = safeJSONParse(node?node.textContent:null, { backgrounds:[], songs:[] });
+    return {
+      backgrounds: dedupeBackgrounds(normalizeBackgrounds(parsed.backgrounds)),
+      songs: dedupeSongs(normalizeSongs(parsed.songs))
+    };
+  })();
+
+  const storageAvailable = (()=>{
+    try{
+      const key='__heardle_storage__';
+      window.localStorage.setItem(key,'1');
+      window.localStorage.removeItem(key);
+      return true;
+    }catch{
+      return false;
+    }
+  })();
+
+  const storedCustom = storageAvailable ? safeJSONParse(window.localStorage.getItem(STORAGE_KEY), { backgrounds:[], songs:[] }) : { backgrounds:[], songs:[] };
+
+  const customConfig = {
+    backgrounds: dedupeBackgrounds(normalizeBackgrounds(storedCustom.backgrounds)),
+    songs: dedupeSongs(normalizeSongs(storedCustom.songs))
+  };
+
+  const warnIfNoStorage = (()=>{
+    let warned=false;
+    return ()=>{
+      if (storageAvailable || warned) return;
+      warned=true;
+      log('Storage is unavailable; custom entries reset after reload.');
+    };
+  })();
+
+  let backgrounds = dedupeBackgrounds([...(baseConfig.backgrounds||[]), ...(customConfig.backgrounds||[])]);
+  let songs = dedupeSongs([...(baseConfig.songs||[]), ...(customConfig.songs||[])]);
 
   const DURATIONS = [1,2,4,7,11,16]; // seconds
+
+  function persistCustomConfig(){
+    if(!storageAvailable) return false;
+    try{
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(customConfig));
+      return true;
+    }catch(e){
+      log('Saving custom config failed: '+e.message);
+      return false;
+    }
+  }
+
+  function refreshRuntimeConfig(){
+    backgrounds = dedupeBackgrounds([...(baseConfig.backgrounds||[]), ...(customConfig.backgrounds||[])]);
+    songs = dedupeSongs([...(baseConfig.songs||[]), ...(customConfig.songs||[])]);
+    populateDatalist();
+    setDailyBackground();
+  }
 
   /* ==================== STATE ==================== */
   let player, isReady=false, audioUnlocked=false, gameOver=false, clipTimer=null;
@@ -142,11 +249,11 @@
   let currentSong=null;
 
   /* ==================== UTILS ==================== */
-  const $ = sel => document.querySelector(sel);
-  function log(msg){ const d=$('#diag'); d.textContent=(d.textContent+' '+msg).trim().slice(-2000); d.scrollTop=d.scrollHeight; }
-  const sleep = ms => new Promise(r=>setTimeout(r,ms));
-
-  function dailyIndex(mod){ const day=Math.floor(Date.now()/86400000); return ((day%mod)+mod)%mod; }
+  function dailyIndex(mod){
+    if(!mod) return 0;
+    const day=Math.floor(Date.now()/86400000);
+    return ((day%mod)+mod)%mod;
+  }
 
   async function loadBackgroundSafe(urls, timeoutMs=3500){
 
@@ -191,13 +298,13 @@
     return false;
   }
 
-  function populateDatalist(){ const dl=$('#songs'); dl.innerHTML=''; const seen=new Set(); for(const s of SONGS){ if(!s.title||seen.has(s.title)) continue; seen.add(s.title); const o=document.createElement('option'); o.value=s.title; dl.appendChild(o);} }
+  function populateDatalist(){ const dl=$('#songs'); if(!dl) return; dl.innerHTML=''; const seen=new Set(); for(const s of songs){ if(!s.title||seen.has(s.title)) continue; seen.add(s.title); const o=document.createElement('option'); o.value=s.title; if(s.game) o.label=s.game; dl.appendChild(o);} }
 
   function pickSong(){
-    if (!SONGS.length) return null;
-    let idx = dailyIndex(SONGS.length);
-    for (let i=0;i<SONGS.length;i++){
-      const s = SONGS[(idx+i)%SONGS.length];
+    if (!songs.length) return null;
+    let idx = dailyIndex(songs.length);
+    for (let i=0;i<songs.length;i++){
+      const s = songs[(idx+i)%songs.length];
       if (!s.videoId) continue; if (failedIds.has(s.videoId)) continue; return s;
     } return null;
   }
@@ -276,11 +383,24 @@
   }
 
   /* ==================== GAME FLOW ==================== */
-  async function setDailyBackground(){ const startIdx=dailyIndex(BACKGROUNDS.length); const ordered=BACKGROUNDS.map((_,i)=>BACKGROUNDS[(startIdx+i)%BACKGROUNDS.length]); await loadBackgroundSafe(ordered); }
+  async function setDailyBackground(){
+    if (!backgrounds.length){
+      document.body.style.backgroundImage='radial-gradient(1200px 600px at 50% -10%, rgba(255,215,0,.12), rgba(0,0,0,0) 60%), linear-gradient(#0e0e0e,#1a1a1a)';
+      return;
+    }
+    const startIdx=dailyIndex(backgrounds.length);
+    const ordered=[];
+    for(let i=0;i<backgrounds.length;i++){
+      ordered.push(backgrounds[(startIdx+i)%backgrounds.length]);
+    }
+    await loadBackgroundSafe(ordered);
+  }
 
   async function startRound(){
     $('#gate-row').style.display='none'; $('#guess-section').style.display='block';
-    await setDailyBackground(); populateDatalist(); await startNewSong(true);
+    setDailyBackground();
+    populateDatalist();
+    await startNewSong(true);
   }
 
   async function startNewSong(first=false){
@@ -291,17 +411,48 @@
     try{ player.cueVideoById(currentSong.videoId); }catch(e){ log('cue error: '+e.message); failedIds.add(currentSong.videoId); return startNewSong(); }
 
     // Wait for CUED (or timeout) then try a muted nudge, then play clip.
-    await Promise.race([ new Promise(r=>{ const t=setInterval(()=>{ try{ if(player.getPlayerState()===YT.PlayerState.CUED){ clearInterval(t); r(); } }catch{} },50); }), sleep(700) ]);
+    await Promise.race([ new Promise(r=>{ const t=setInterval(()=>{ try{ if(player.getPlayerState()===YT.PlayerState.CUED){ clearInterval(t); r(); } }catch{} },50); }), sleep(1500) ]);
 
+    if(first) await primePlayerForAutoplay();
     playClip();
+  }
+
+  async function primePlayerForAutoplay(options={}){
+    const silent=!!options.silent;
+    if (!player || typeof player.playVideo!=='function'){
+      if(!silent) log('Player not ready to prime yet.');
+      return;
+    }
+    try{
+      player.mute();
+      player.seekTo(0,true);
+      player.playVideo();
+      await sleep(180);
+      player.pauseVideo();
+      player.unMute();
+      if(!silent) log('Player primed for autoplay');
+    }catch(e){
+      if(!silent) log('Autoplay prime failed: '+e.message);
+    }
   }
 
   function playClip(){
     if (gameOver || !currentSong) return; clearTimeout(clipTimer);
     const sec=DURATIONS[Math.min(attempt, DURATIONS.length-1)];
-    try{ player.seekTo(0,true); player.playVideo(); }catch{}
+    try{ player.unMute(); player.seekTo(0,true); player.playVideo(); }catch{}
     log('Playing clip '+sec+'s');
     clipTimer=setTimeout(()=>{ if(!gameOver){ try{ player.pauseVideo(); }catch{} log('Clip paused'); } }, sec*1000);
+    setTimeout(()=>{ (async()=>{
+      if (gameOver || !player || !window.YT) return;
+      try{
+        const state=player.getPlayerState();
+        if(state!==YT.PlayerState.PLAYING){
+          log('Autoplay blocked; retrying prime…');
+          await primePlayerForAutoplay({ silent:true });
+          try{ player.playVideo(); }catch{}
+        }
+      }catch(e){ log('Playback check failed: '+e.message); }
+    })(); }, 420);
   }
 
   function submitGuess(){
@@ -334,6 +485,79 @@
     }
   }
 
+  /* ==================== CUSTOM DATA HELPERS ==================== */
+  const HeardleAdmin = {
+    addSong(song){
+      const normalized = normalizeSongs([song])[0];
+      if(!normalized) throw new Error('Song must include at least a title.');
+      customConfig.songs = dedupeSongs([...(customConfig.songs||[]), normalized]);
+      refreshRuntimeConfig();
+      if(!persistCustomConfig()) warnIfNoStorage();
+      log(`Custom song added: ${normalized.title}`);
+      if(!normalized.videoId){ log('Note: this song has no videoId yet, so it will be skipped until added.'); }
+      return normalized;
+    },
+    addBackground(url){
+      const normalized = normalizeBackgrounds([url])[0];
+      if(!normalized) throw new Error('Background URL is required.');
+      customConfig.backgrounds = dedupeBackgrounds([...(customConfig.backgrounds||[]), normalized]);
+      refreshRuntimeConfig();
+      if(!persistCustomConfig()) warnIfNoStorage();
+      log(`Custom background added: ${normalized}`);
+      return normalized;
+    },
+    listSongs(){ return songs.slice(); },
+    listBackgrounds(){ return backgrounds.slice(); },
+    exportCustom(){ return JSON.stringify(customConfig, null, 2); },
+    importCustom(data){
+      const parsed = typeof data==='string' ? safeJSONParse(data, null) : data;
+      if(!parsed) throw new Error('Invalid custom data payload.');
+      customConfig.songs = dedupeSongs(normalizeSongs(parsed.songs));
+      customConfig.backgrounds = dedupeBackgrounds(normalizeBackgrounds(parsed.backgrounds));
+      refreshRuntimeConfig();
+      if(!persistCustomConfig()) warnIfNoStorage();
+      log('Custom config imported.');
+      return { ...customConfig };
+    },
+    resetCustom(){
+      customConfig.songs = [];
+      customConfig.backgrounds = [];
+      refreshRuntimeConfig();
+      if(!persistCustomConfig()) warnIfNoStorage();
+      log('Custom config cleared.');
+    },
+    getCombinedConfig(){
+      return { backgrounds: backgrounds.slice(), songs: songs.slice() };
+    }
+  };
+  window.HeardleAdmin = HeardleAdmin;
+
+  if (storageAvailable){
+    window.addEventListener('storage', (event)=>{
+      if(event.key!==STORAGE_KEY) return;
+      const next = safeJSONParse(event.newValue, { backgrounds:[], songs:[] });
+      customConfig.songs = dedupeSongs(normalizeSongs(next.songs));
+      customConfig.backgrounds = dedupeBackgrounds(normalizeBackgrounds(next.backgrounds));
+      refreshRuntimeConfig();
+      log('Custom config reloaded from another tab.');
+    });
+  }
+
+  refreshRuntimeConfig();
+  log(`Loaded ${songs.length} songs (${customConfig.songs.length} custom).`);
+  if(customConfig.backgrounds.length){ log(`Loaded ${customConfig.backgrounds.length} custom backgrounds.`); }
+  log('Tip: open the browser console and use window.HeardleAdmin to manage custom songs and backgrounds.');
+
+  window.HeardleGame = {
+    start: startRound,
+    restart: ()=>startNewSong(false),
+    newSong: startNewSong,
+    get songs(){ return songs.slice(); },
+    get backgrounds(){ return backgrounds.slice(); },
+    primePlayer: primePlayerForAutoplay,
+    get custom(){ return { ...customConfig }; }
+  };
+
   /* ==================== WIRE UP ==================== */
   window.addEventListener('pageshow',()=>{ setDailyBackground(); });
   document.addEventListener('visibilitychange',()=>{ if(document.hidden){ clearTimeout(clipTimer); } });
@@ -346,6 +570,7 @@
     if (!isReady){ log('Waiting for YT…'); for(let i=0;i<20 && !isReady;i++){ await sleep(150);} }
     if (!isReady){ $('#result').textContent='YouTube failed to initialize. Check CSP or connection.'; $('#result').style.color='red'; return; }
     installGestureUnlock();
+    await primePlayerForAutoplay({ silent:true });
     await startRound();
   });
 


### PR DESCRIPTION
## Summary
- move the song and background lists into a JSON config block that can be extended without touching the logic
- add runtime helpers and localStorage persistence so additional songs/backgrounds can be managed from the browser console
- adjust autoplay priming and fallback logic so the first clip starts reliably while keeping gesture unlock fallbacks
- expose a small control surface (window.HeardleGame/HeardleAdmin) to help future hosting options such as Streamlit

## Testing
- not run (static HTML/JS changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f8805a1f08328b0383f4b9120dbf6)